### PR TITLE
Update Theme Park URL

### DIFF
--- a/full-vpn_multiple-yaml/docker-compose-bazarr.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-bazarr.yaml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:bazarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:bazarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_multiple-yaml/docker-compose-lidarr.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-lidarr.yaml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:lidarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:lidarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_multiple-yaml/docker-compose-mylar3.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-mylar3.yaml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:mylar3
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:mylar3
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_multiple-yaml/docker-compose-prowlarr.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-prowlarr.yaml
@@ -21,7 +21,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:prowlarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:prowlarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_multiple-yaml/docker-compose-qbittorrent.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-qbittorrent.yaml
@@ -24,7 +24,7 @@ services:
       - UMASK=${UMASK:?err}
       - TZ=${TIMEZONE:?err}
       - WEBUI_PORT=${WEBUI_PORT_QBITTORRENT:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:qbittorrent
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:qbittorrent
       - TP_THEME=${TP_THEME:?err}
 
 ## Do Not Change Network for qBittorrent

--- a/full-vpn_multiple-yaml/docker-compose-radarr.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-radarr.yaml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:radarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:radarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_multiple-yaml/docker-compose-readarr.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-readarr.yaml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:readarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:readarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_multiple-yaml/docker-compose-sabnzbd.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-sabnzbd.yaml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sabnzbd
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sabnzbd
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_multiple-yaml/docker-compose-sonarr.yaml
+++ b/full-vpn_multiple-yaml/docker-compose-sonarr.yaml
@@ -22,7 +22,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sonarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sonarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "container:gluetun"
 

--- a/full-vpn_single-yaml/docker-compose-media-stack.yaml
+++ b/full-vpn_single-yaml/docker-compose-media-stack.yaml
@@ -132,7 +132,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:bazarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:bazarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:
@@ -314,7 +314,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:lidarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:lidarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:
@@ -341,7 +341,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:mylar3
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:mylar3
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:
@@ -367,7 +367,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:prowlarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:prowlarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:
@@ -396,7 +396,7 @@ services:
       - UMASK=${UMASK:?err}
       - TZ=${TIMEZONE:?err}
       - WEBUI_PORT=${WEBUI_PORT_QBITTORRENT:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:qbittorrent
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:qbittorrent
       - TP_THEME=${TP_THEME:?err}
 ## Do Not Change Network for qBittorrent
 ## qBittorrent MUST always use a VPN / Secure Internet connection
@@ -423,7 +423,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:radarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:radarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:
@@ -450,7 +450,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:readarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:readarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:
@@ -477,7 +477,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sabnzbd
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sabnzbd
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:
@@ -504,7 +504,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sonarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sonarr
       - TP_THEME=${TP_THEME:?err}
     network_mode: "service:gluetun"
 #    ports:

--- a/min-vpn_mulitple-yaml/docker-compose-bazarr.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-bazarr.yaml
@@ -24,7 +24,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:bazarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:bazarr
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_mulitple-yaml/docker-compose-lidarr.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-lidarr.yaml
@@ -24,7 +24,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:lidarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:lidarr
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_mulitple-yaml/docker-compose-mylar3.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-mylar3.yaml
@@ -24,7 +24,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:mylar3
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:mylar3
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_mulitple-yaml/docker-compose-prowlarr.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-prowlarr.yaml
@@ -23,7 +23,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:prowlarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:prowlarr
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_mulitple-yaml/docker-compose-qbittorrent.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-qbittorrent.yaml
@@ -24,7 +24,7 @@ services:
       - UMASK=${UMASK:?err}
       - TZ=${TIMEZONE:?err}
       - WEBUI_PORT=${WEBUI_PORT_QBITTORRENT:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:qbittorrent
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:qbittorrent
       - TP_THEME=${TP_THEME:?err}
 
 ## Do Not Change Network for qBittorrent

--- a/min-vpn_mulitple-yaml/docker-compose-radarr.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-radarr.yaml
@@ -24,7 +24,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:radarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:radarr
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_mulitple-yaml/docker-compose-readarr.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-readarr.yaml
@@ -24,7 +24,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:readarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:readarr
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_mulitple-yaml/docker-compose-sabnzbd.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-sabnzbd.yaml
@@ -24,7 +24,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sabnzbd
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sabnzbd
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_mulitple-yaml/docker-compose-sonarr.yaml
+++ b/min-vpn_mulitple-yaml/docker-compose-sonarr.yaml
@@ -24,7 +24,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sonarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sonarr
       - TP_THEME=${TP_THEME:?err}
 
 networks:

--- a/min-vpn_single-yaml/docker-compose-media-stack.yaml
+++ b/min-vpn_single-yaml/docker-compose-media-stack.yaml
@@ -117,7 +117,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:bazarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:bazarr
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network
@@ -310,7 +310,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:lidarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:lidarr
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network
@@ -338,7 +338,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:mylar3
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:mylar3
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network
@@ -365,7 +365,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:prowlarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:prowlarr
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network
@@ -393,7 +393,7 @@ services:
       - UMASK=${UMASK:?err}
       - TZ=${TIMEZONE:?err}
       - WEBUI_PORT=${WEBUI_PORT_QBITTORRENT:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:qbittorrent
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:qbittorrent
       - TP_THEME=${TP_THEME:?err}
 
 ## Do Not Change Network for qBittorrent
@@ -424,7 +424,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:radarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:radarr
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network
@@ -452,7 +452,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:readarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:readarr
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network
@@ -480,7 +480,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sabnzbd
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sabnzbd
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network
@@ -508,7 +508,7 @@ services:
       - PUID=${PUID:?err}
       - PGID=${PGID:?err}
       - TZ=${TIMEZONE:?err}
-      - DOCKER_MODS=ghcr.io/gilbn/theme.park:sonarr
+      - DOCKER_MODS=ghcr.io/themepark-dev/theme.park:sonarr
       - TP_THEME=${TP_THEME:?err}
     networks:
       - media-network


### PR DESCRIPTION
This commit updates the URL for the Theme Park mod, from `ghcr.io/gilbn/theme.park` to `ghcr.io/themepark-dev/theme.park` as recommended by the project's readme.