### PR TITLE
Add dependency on gluetun

### DIFF
--- a/full-vpn_single-yaml/docker-compose-mediastack.yaml
+++ b/full-vpn_single-yaml/docker-compose-mediastack.yaml
@@ -228,6 +228,9 @@ services:
       - TZ=${TIMEZONE:?err}
       - DARK_MODE=1
     network_mode: "container:gluetun"
+    depends_on:
+       gluetun:
+          condition: service_started
 #    ports:
 #      - "${WEBUI_PORT_FILEBOT:?err}:5454"             # Configured in Gluetun VPN container
 
@@ -307,6 +310,9 @@ services:
       - UMASK=${UMASK:?err}
       - TZ=${TIMEZONE:?err}
     network_mode: "container:gluetun"
+    depends_on:
+       gluetun:
+          condition: service_started
 #    ports:
 #      - "${WEBUI_PORT_HOMARR:?err}:7575"             # Configured in Gluetun VPN container
 


### PR DESCRIPTION
To avoid such errors when deploying:

Failed to deploy a stack: compose up operation failed: Error response from daemon: cannot join network namespace of a non running container: container gluetun is created