### PR TITLE
Added SWAG config patch script

### DIFF
--- a/swag_config_patcher.py
+++ b/swag_config_patcher.py
@@ -43,7 +43,7 @@ for container in stack_full:
     text = file.read_text()
 
     # Patch ports
-    if port:
+    if port and not container in stack_network:
         text = re.sub(r'set \$upstream_port \d{2,5};', f'set $upstream_port {port};', text)
     # Activate authelia
     if use_authelia:

--- a/swag_config_patcher.py
+++ b/swag_config_patcher.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+import os
+import re
+
+from pathlib import Path
+
+use_authelia = True
+use_full_vpn = True
+
+# Check paths
+FOLDER_FOR_DATA = os.getenv('FOLDER_FOR_DATA')
+if not FOLDER_FOR_DATA:
+    print('Data folder not in ENV.')
+    exit(1)
+data_dir = Path(FOLDER_FOR_DATA)
+proxy_conf_dir = data_dir / 'swag/nginx/proxy-confs'
+if not proxy_conf_dir.is_dir():
+    print('SWAG proxy config folder does not exist.')
+    exit(2)
+auth_conf_path = data_dir / 'swag/nginx/site-confs/default.conf'
+if not auth_conf_path.is_file():
+    print('SWAG default site config does not exist.')
+    exit(3)
+
+# Container / config names
+stack_network = {'authelia', 'heimdall', 'homarr', 'homepage', 'ddns-updater'}
+stack_vpn = {'bazarr', 'filebot', 'flaresolverr', 'jellyfin', 'jellyseerr', 'lidarr', 'mylar', 'plex', 'portainer', 'prowlarr', 'qbittorrent', 'radarr', 'readarr', 'sabnzbd', 'sonarr', 'tdarr', 'whisparr'}
+stack_full = stack_network | stack_vpn
+
+for container in stack_full:
+    print(f'Processing "{container}".')
+
+    # Get port from env
+    caps = container.upper().replace('-', '_')
+    port = os.getenv(f'WEBUI_PORT_{caps}') or os.getenv(f'{caps}_PORT')
+
+    # Read sample config
+    file = proxy_conf_dir / f'{container}.subdomain.conf.sample'
+    if not file.is_file():
+        print(f'Can not find config file "{file}".')
+        continue
+    text = file.read_text()
+
+    # Patch ports
+    if port:
+        text = re.sub(r'set \$upstream_port \d{2,5};', f'set $upstream_port {port};', text)
+    # Activate authelia
+    if use_authelia:
+        text = text.replace('#include /config/nginx/authelia', 'include /config/nginx/authelia')
+    # Rewire to gluetun
+    if use_full_vpn and container in stack_vpn:
+        text = text.replace(f'set $upstream_app {container};', 'set $upstream_app gluetun;')
+    # Rename subdomain for authelia to auth
+    if container == 'authelia':
+        text = text.replace('server_name authelia.*;', 'server_name auth.*;')
+
+    conf = file.with_suffix('').write_text(text)
+
+# Activate authelia in default config
+# FIXME: Do we need this?
+if use_authelia:
+    text = auth_conf_path.read_text()
+    text = text.replace('#include /config/nginx/authelia', 'include /config/nginx/authelia')
+    auth_conf_path.write_text(text)


### PR DESCRIPTION
This is a quick and dirty script, that patches the config of SWAG. Currently there are several issues, that aren't documented in the guide:

- Changing ports require config updates
- Some default ports differ from what SWAG expects
- If your setup relies on gluetun (full VPN setup), you need to rewire all requests to the gluetun container
- Also it automates enabling authelia, if desired

We just read the env from the file and copy the samples patched to actual conf files.

```bash
(set -a && source 'docker-compose.env' && set +a && python3 swag_config_patcher.py)
```

We may need some documentation in the guide for this, but it solved a lot of headaches for me.

EDIT: Only `homarr`, `portainer`, `sabnzbd` are not reachable now. `(111: Connection refused)` - Not sure what's the issue here.

EDIT2: `portainer` is not part of `full-vpn_single-yaml` and `homarr` should be fixed.

EDIT3: `sabnzbd` works if it's port is set to 8080, which is the default port. All other containers use their default ports. This is a bit odd, but I don't know the `gluetun` workflow. All other containers use their default ports by default.

EDIT4: The `gluetun` setup should not use configurable ports or set them in each container internally.. https://github.com/qdm12/gluetun-wiki/blob/main/setup/port-mapping.md