### PR TITLE
fix: update to point to tdarr, and fix to use IPv4 instead of v6

### DIFF
--- a/mini-download-vpn/docker-compose.yaml
+++ b/mini-download-vpn/docker-compose.yaml
@@ -1450,8 +1450,9 @@ services:
       - UMASK=${UMASK:?err}
       - TZ=${TIMEZONE:?err}
       - nodeID=Tdarr_Node_1
-      - serverIP=0.0.0.0
+      - serverIP=tdarr
       - serverPort=${TDARR_SERVER_PORT:?err}
+      - NODE_OPTIONS=--dns-result-order=ipv4first
     networks:
       - mediastack
 


### PR DESCRIPTION
you should merge these changes  back to get `tdarr` service to recognize/find `tdarr-node`.  Additionally so tdarr-node service can come online and not error out looking for ipv6.