### PR TITLE
Moved ARR API Tokens away from under unpackerr docker config to .env

### DIFF
--- a/base-working-files/.env
+++ b/base-working-files/.env
@@ -123,6 +123,16 @@ WEBUI_PORT_WHISPARR=6969
 
 CHROMIUM_START_PAGE="https://github.com/geekau/mediastack/"
 
+# *ARR API Tokens
+# Generate these in each service as needed
+# Unpackerr uses these in the form: UN_<service>_0_API_TOKEN
+MYLAR_API_TOKEN=01234567890abcdef01234567890abcdef
+SONARR_API_TOKEN=01234567890abcdef01234567890abcdef
+RADARR_API_TOKEN=01234567890abcdef01234567890abcdef
+LIDARR_API_TOKEN=01234567890abcdef01234567890abcdef
+READARR_API_TOKEN=01234567890abcdef01234567890abcdef
+WHISPARR_API_TOKEN=01234567890abcdef01234567890abcdef
+
 # Traefik is configured for Reverse Proxy. Set your Internet gateway to redirect incoming ports 80 and 443
 # to the ports used below (using Docker IP Address), and they will be translated back to 80 and 443 by Traefik.
 # Change these port numbers if you have conflicting services running on the Docker host computer.

--- a/full-download-vpn/docker-compose.yaml
+++ b/full-download-vpn/docker-compose.yaml
@@ -1634,7 +1634,7 @@ services:
       ## Mylar Settings
       ## Mylar Config - Copy API Key from: http://mylar:8090/general/settings
       - UN_MYLAR_0_URL=http://mylar:8090
-      - UN_MYLAR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_MYLAR_0_API_KEY=${MYLAR_API_TOKEN}
       - UN_MYLAR_0_PATHS_0=/data/torrents/comics
       - UN_MYLAR_0_PROTOCOLS=torrent
       - UN_MYLAR_0_TIMEOUT=10s
@@ -1644,7 +1644,7 @@ services:
       ## Sonarr Settings
       ## Sonarr Config - Copy API Key from: http://sonarr:8989/general/settings
       - UN_SONARR_0_URL=http://sonarr:8989
-      - UN_SONARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_SONARR_0_API_KEY=${SONARR_API_TOKEN}
       - UN_SONARR_0_PATHS_0=/data/torrents/anime
       - UN_SONARR_0_PATHS_1=/data/torrents/tv
       - UN_SONARR_0_PROTOCOLS=torrent
@@ -1655,7 +1655,7 @@ services:
       ## Radarr Settings
       ## Radarr Config - Copy API Key from: http://radarr:7878/general/settings
       - UN_RADARR_0_URL=http://radarr:7878
-      - UN_RADARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_RADARR_0_API_KEY=${RADARR_API_TOKEN}
       - UN_RADARR_0_PATHS_0=/data/torrents/movies
       - UN_RADARR_0_PROTOCOLS=torrent
       - UN_RADARR_0_TIMEOUT=10s
@@ -1665,7 +1665,7 @@ services:
       ## Lidarr Settings
       ## Lidarr Config - Copy API Key from: http://lidarr:8686/general/settings
       - UN_LIDARR_0_URL=http://lidarr:8686
-      - UN_LIDARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_LIDARR_0_API_KEY=${LIDARR_API_TOKEN}
       - UN_LIDARR_0_PATHS_0=/data/torrents/music
       - UN_LIDARR_0_PROTOCOLS=torrent
       - UN_LIDARR_0_TIMEOUT=10s
@@ -1675,7 +1675,7 @@ services:
       ## Readarr Settings
       ## Readarr Config - Copy API Key from: http://readarr:8787/general/settings
       - UN_READARR_0_URL=http://readarr:8787
-      - UN_READARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_READARR_0_API_KEY=${READARR_API_TOKEN}
       - UN_READARR_0_PATHS_0=/data/torrents/books
       - UN_READARR_0_PROTOCOLS=torrent
       - UN_READARR_0_TIMEOUT=10s
@@ -1685,7 +1685,7 @@ services:
       ## Whisparr Settings
       ## Whisparr Config - Copy API Key from: http://readarr:6969/general/settings
       - UN_WHISPARR_0_URL=http://whisparr:6969
-      - UN_WHISPARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_WHISPARR_0_API_KEY=${WHISPARR_API_TOKEN}
       - UN_WHISPARR_0_PATHS_0=/data/torrents/xxx
       - UN_WHISPARR_0_PROTOCOLS=torrent
       - UN_WHISPARR_0_TIMEOUT=10s

--- a/mini-download-vpn/docker-compose.yaml
+++ b/mini-download-vpn/docker-compose.yaml
@@ -1516,7 +1516,7 @@ services:
       ## Mylar Settings
       ## Mylar Config - Copy API Key from: http://mylar:8090/general/settings
       - UN_MYLAR_0_URL=http://mylar:8090
-      - UN_MYLAR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_MYLAR_0_API_KEY=${MYLAR_API_TOKEN}
       - UN_MYLAR_0_PATHS_0=/data/torrents/comics
       - UN_MYLAR_0_PROTOCOLS=torrent
       - UN_MYLAR_0_TIMEOUT=10s
@@ -1526,7 +1526,7 @@ services:
       ## Sonarr Settings
       ## Sonarr Config - Copy API Key from: http://sonarr:8989/general/settings
       - UN_SONARR_0_URL=http://sonarr:8989
-      - UN_SONARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_SONARR_0_API_KEY=${SONARR_API_TOKEN}
       - UN_SONARR_0_PATHS_0=/data/torrents/anime
       - UN_SONARR_0_PATHS_1=/data/torrents/tv
       - UN_SONARR_0_PROTOCOLS=torrent
@@ -1537,7 +1537,7 @@ services:
       ## Radarr Settings
       ## Radarr Config - Copy API Key from: http://radarr:7878/general/settings
       - UN_RADARR_0_URL=http://radarr:7878
-      - UN_RADARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_RADARR_0_API_KEY=${RADARR_API_TOKEN}
       - UN_RADARR_0_PATHS_0=/data/torrents/movies
       - UN_RADARR_0_PROTOCOLS=torrent
       - UN_RADARR_0_TIMEOUT=10s
@@ -1547,7 +1547,7 @@ services:
       ## Lidarr Settings
       ## Lidarr Config - Copy API Key from: http://lidarr:8686/general/settings
       - UN_LIDARR_0_URL=http://lidarr:8686
-      - UN_LIDARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_LIDARR_0_API_KEY=${LIDARR_API_TOKEN}
       - UN_LIDARR_0_PATHS_0=/data/torrents/music
       - UN_LIDARR_0_PROTOCOLS=torrent
       - UN_LIDARR_0_TIMEOUT=10s
@@ -1557,7 +1557,7 @@ services:
       ## Readarr Settings
       ## Readarr Config - Copy API Key from: http://readarr:8787/general/settings
       - UN_READARR_0_URL=http://readarr:8787
-      - UN_READARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_READARR_0_API_KEY=${READARR_API_TOKEN}
       - UN_READARR_0_PATHS_0=/data/torrents/books
       - UN_READARR_0_PROTOCOLS=torrent
       - UN_READARR_0_TIMEOUT=10s
@@ -1567,7 +1567,7 @@ services:
       ## Whisparr Settings
       ## Whisparr Config - Copy API Key from: http://readarr:6969/general/settings
       - UN_WHISPARR_0_URL=http://whisparr:6969
-      - UN_WHISPARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_WHISPARR_0_API_KEY=${WHISPARR_API_TOKEN}
       - UN_WHISPARR_0_PATHS_0=/data/torrents/xxx
       - UN_WHISPARR_0_PROTOCOLS=torrent
       - UN_WHISPARR_0_TIMEOUT=10s

--- a/no-download-vpn/docker-compose.yaml
+++ b/no-download-vpn/docker-compose.yaml
@@ -1440,7 +1440,7 @@ services:
       ## Mylar Settings
       ## Mylar Config - Copy API Key from: http://mylar:8090/general/settings
       - UN_MYLAR_0_URL=http://mylar:8090
-      - UN_MYLAR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_MYLAR_0_API_KEY=${MYLAR_API_TOKEN}
       - UN_MYLAR_0_PATHS_0=/data/torrents/comics
       - UN_MYLAR_0_PROTOCOLS=torrent
       - UN_MYLAR_0_TIMEOUT=10s
@@ -1450,7 +1450,7 @@ services:
       ## Sonarr Settings
       ## Sonarr Config - Copy API Key from: http://sonarr:8989/general/settings
       - UN_SONARR_0_URL=http://sonarr:8989
-      - UN_SONARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_SONARR_0_API_KEY=${SONARR_API_TOKEN}
       - UN_SONARR_0_PATHS_0=/data/torrents/anime
       - UN_SONARR_0_PATHS_1=/data/torrents/tv
       - UN_SONARR_0_PROTOCOLS=torrent
@@ -1461,7 +1461,7 @@ services:
       ## Radarr Settings
       ## Radarr Config - Copy API Key from: http://radarr:7878/general/settings
       - UN_RADARR_0_URL=http://radarr:7878
-      - UN_RADARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_RADARR_0_API_KEY=${RADARR_API_TOKEN}
       - UN_RADARR_0_PATHS_0=/data/torrents/movies
       - UN_RADARR_0_PROTOCOLS=torrent
       - UN_RADARR_0_TIMEOUT=10s
@@ -1471,7 +1471,7 @@ services:
       ## Lidarr Settings
       ## Lidarr Config - Copy API Key from: http://lidarr:8686/general/settings
       - UN_LIDARR_0_URL=http://lidarr:8686
-      - UN_LIDARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_LIDARR_0_API_KEY=${LIDARR_API_TOKEN}
       - UN_LIDARR_0_PATHS_0=/data/torrents/music
       - UN_LIDARR_0_PROTOCOLS=torrent
       - UN_LIDARR_0_TIMEOUT=10s
@@ -1481,7 +1481,7 @@ services:
       ## Readarr Settings
       ## Readarr Config - Copy API Key from: http://readarr:8787/general/settings
       - UN_READARR_0_URL=http://readarr:8787
-      - UN_READARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_READARR_0_API_KEY=${READARR_API_TOKEN}
       - UN_READARR_0_PATHS_0=/data/torrents/books
       - UN_READARR_0_PROTOCOLS=torrent
       - UN_READARR_0_TIMEOUT=10s
@@ -1491,7 +1491,7 @@ services:
       ## Whisparr Settings
       ## Whisparr Config - Copy API Key from: http://readarr:6969/general/settings
       - UN_WHISPARR_0_URL=http://whisparr:6969
-      - UN_WHISPARR_0_API_KEY=0123456789abcdef0123456789abcdef
+      - UN_WHISPARR_0_API_KEY=${WHISPARR_API_TOKEN}
       - UN_WHISPARR_0_PATHS_0=/data/torrents/xxx
       - UN_WHISPARR_0_PROTOCOLS=torrent
       - UN_WHISPARR_0_TIMEOUT=10s


### PR DESCRIPTION
I don't think API keys should be in the docker-compose.yaml files? Naturally a lot more has to go wrong for this to matter, but the odds of that happening aren't negligible. 

Renamed to be a little more generic in .env so that other apps could use them.